### PR TITLE
Updating README with user-relevant GridItem props; passing itemsLength to GridItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Install with `npm install react-absolute-grid`
 
     import React from 'react';
     import AbsoluteGrid from './lib/AbsoluteGrid.jsx';
-  
+
      var sampleItems = [
       {key: 1, name: 'Test', sort: 0, filtered: 0},
       {key: 2, name: 'Test 1', sort: 1, filtered: 0},
     ];
-     
+
     React.render(<AbsoluteGrid items={sampleItems} />, document.getElementById('Container'));
-    
+
 
 Options (Properties)
 ------
@@ -55,14 +55,25 @@ Display objects will receive item, style, and index as properties. You must appl
       }
     }
 
-Once you've created a display object, use it like this: 
-     
+Once you've created a display object, use it like this:
+
      var dispalyObject = (<SampleDisplay />);
      var grid = (<AbsoluteGrid ... displayObject={displayObject}/>);
 
 What Makes AbsoluteGrid Unique?
 ----
 The idea behind AbsoluteGrid is high performance. This is achieved by using Translate3d to position each item in the layout. Items are never removed from the DOM, instead they are hidden. For best performance you should avoid re-arranging or removing items which you pass into AbsoluteGrid, instead you can use the `filtered` and `sort` properties to hide or sort an item. Those properties are customizable using the `keyProp` and `filterProp` properties.
+
+GridItem props
+----
+Each GridItem component is passed the following props.
+
+| Property | Description |
+|---|:---|
+| **style** | The inline styles that ReactAbsoluteGrid generates for the grid item. **NOTE**: Remember to apply to your GridItem element |
+| **item** | The data associated with the GridItem |
+| **index** | The index of the item data in the `items` array |
+| **itemsLength** | The total length of the `items` array |
 
 
 ToDo:

--- a/lib/AbsoluteGrid.jsx
+++ b/lib/AbsoluteGrid.jsx
@@ -60,6 +60,7 @@ export default class AbsoluteGrid extends React.Component {
       var gridItem = React.cloneElement(this.props.displayObject, _.assign(this.props.displayObject.props, {
         style: style,
         item: item,
+        itemsLength: this.props.items.length,
         index: index,
         key: key,
         dragEnabled: this.props.dragEnabled,


### PR DESCRIPTION
Submitting this PR for the following:

Updating the documentation to display relevant GridItem props that I think the user should be aware of

Passing itemsLength down as a prop to GridItem. I ran into a scenario where I needed to apply the z-index in reverse order on the GridItems, and I needed the total length of the data set to derive the z-indicies
