### PR TITLE
Add explicit npmignore so it doesn't default to gitignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+node_modules/
+
+demo/
+demo.js
+
+webpack/
+
+.idea
+.babelrc
+.editorconfig
+.eslintrc


### PR DESCRIPTION
@conorhastings Must have explicit npmignore so that lib/
folder gets published to npm. Right now it defaults to
gitignore and doesn't publish lib/.
